### PR TITLE
fix: firebase configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "firebase": "^9.19.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.10.0",

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,4 +1,6 @@
-import firebase from './firebase';
+import { initializeApp } from 'firebase/app';
+import { getAuth } from "firebase/auth";
+import { getFirestore } from 'firebase/firestore/lite';
 
 const firebaseConfig = {
     apiKey: "AIzaSyBv6zEONDVJSxOlkxmyUVto6eWksYVXwSU",
@@ -10,10 +12,9 @@ const firebaseConfig = {
     measurementId: "G-5BDLQRB305"
 };
 
-const firebaseApp = firebase.initializeApp(firebaseConfig);
+const firebaseApp = initializeApp(firebaseConfig);
 
-const db = firebaseApp.firestore();
-const auth = firebase.auth();
+const db = getFirestore(firebaseApp);
+const auth = getAuth();
 
-export default firebase;
 export { db, auth };


### PR DESCRIPTION
The import in `src/firebase.js`:

```
import firebase from './firebase';
```

is causing a webpack error, because a module cannot import itself

![image](https://user-images.githubusercontent.com/19681625/232624982-7edf9ce1-b412-4efa-9913-9304390f8aba.png)


A correct way to config firebase would be:

- install firebase with `npm install firebase`, which add A dependency in `package.json`
- initialize firebase `auth` with `const auth = getAuth(app);`
- initialize firestore `db` with `const db = getFirestore(firebaseApp);`

you can refer the documentation for details: https://firebase.google.com/docs/auth/web/start